### PR TITLE
Opening sub panels now always replace current tab.

### DIFF
--- a/opi/boy/EVG/ACSynchronization.opi
+++ b/opi/boy/EVG/ACSynchronization.opi
@@ -118,7 +118,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVG/DistributedBus.opi
+++ b/opi/boy/EVG/DistributedBus.opi
@@ -79,7 +79,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVG/EventClock.opi
+++ b/opi/boy/EVG/EventClock.opi
@@ -272,7 +272,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVG/Events.opi
+++ b/opi/boy/EVG/Events.opi
@@ -79,7 +79,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVG/GeneralSettings.opi
+++ b/opi/boy/EVG/GeneralSettings.opi
@@ -118,7 +118,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVG/Inputs_VME-EVG-230.opi
+++ b/opi/boy/EVG/Inputs_VME-EVG-230.opi
@@ -79,7 +79,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVG/Interrupts.opi
+++ b/opi/boy/EVG/Interrupts.opi
@@ -119,7 +119,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVG/Main.opi
+++ b/opi/boy/EVG/Main.opi
@@ -94,7 +94,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>General Settings...</description>
       </action>
     </actions>
@@ -271,7 +271,7 @@ EVG</text>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Event Clock...</description>
       </action>
     </actions>
@@ -326,7 +326,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Multiplexed Counters...</description>
       </action>
     </actions>
@@ -381,7 +381,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Inputs...</description>
       </action>
     </actions>
@@ -436,7 +436,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Outputs...</description>
       </action>
     </actions>
@@ -491,7 +491,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>AC Synchronization...</description>
       </action>
     </actions>
@@ -658,7 +658,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Distributed Bus...</description>
       </action>
     </actions>
@@ -713,7 +713,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Events...</description>
       </action>
     </actions>
@@ -1289,7 +1289,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Interrupts...</description>
       </action>
     </actions>
@@ -1344,7 +1344,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>SFP Module...</description>
       </action>
     </actions>

--- a/opi/boy/EVG/MultiplexedCounters.opi
+++ b/opi/boy/EVG/MultiplexedCounters.opi
@@ -79,7 +79,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVG/Outputs_VME-EVG-230.opi
+++ b/opi/boy/EVG/Outputs_VME-EVG-230.opi
@@ -79,7 +79,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVG/SFPModule.opi
+++ b/opi/boy/EVG/SFPModule.opi
@@ -79,7 +79,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/CMLOutput16PulseGenerators.opi
+++ b/opi/boy/EVR/CMLOutput16PulseGenerators.opi
@@ -349,7 +349,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>CML Configuration...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/CMLOutputConfig.opi
+++ b/opi/boy/EVR/CMLOutputConfig.opi
@@ -119,7 +119,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Outputs...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/DistributedBus_MTCA-EVR-300.opi
+++ b/opi/boy/EVR/DistributedBus_MTCA-EVR-300.opi
@@ -119,7 +119,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/DistributedBus_VME-EVR-230RF.opi
+++ b/opi/boy/EVR/DistributedBus_VME-EVR-230RF.opi
@@ -119,7 +119,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/EventClock_MTCA-EVR-300.opi
+++ b/opi/boy/EVR/EventClock_MTCA-EVR-300.opi
@@ -375,7 +375,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/EventClock_VME-EVR-230RF.opi
+++ b/opi/boy/EVR/EventClock_VME-EVR-230RF.opi
@@ -275,7 +275,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/Events.opi
+++ b/opi/boy/EVR/Events.opi
@@ -119,7 +119,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/GeneralSettings_MTCA-EVR-300.opi
+++ b/opi/boy/EVR/GeneralSettings_MTCA-EVR-300.opi
@@ -119,7 +119,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/GeneralSettings_VME-EVR-230RF.opi
+++ b/opi/boy/EVR/GeneralSettings_VME-EVR-230RF.opi
@@ -119,7 +119,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/Inputs_MTCA-EVR-300.opi
+++ b/opi/boy/EVR/Inputs_MTCA-EVR-300.opi
@@ -79,7 +79,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/Inputs_VME-EVR-230RF.opi
+++ b/opi/boy/EVR/Inputs_VME-EVR-230RF.opi
@@ -79,7 +79,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/Interrupts_MTCA-EVR-300.opi
+++ b/opi/boy/EVR/Interrupts_MTCA-EVR-300.opi
@@ -79,7 +79,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/Interrupts_VME-EVR-230RF.opi
+++ b/opi/boy/EVR/Interrupts_VME-EVR-230RF.opi
@@ -79,7 +79,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/Main_MTCA-EVR-300.opi
+++ b/opi/boy/EVR/Main_MTCA-EVR-300.opi
@@ -41,7 +41,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>General Settings...</description>
       </action>
     </actions>
@@ -217,7 +217,7 @@ EVG or EVR</text>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Event Clock...</description>
       </action>
     </actions>
@@ -272,7 +272,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Pulse Generators...</description>
       </action>
     </actions>
@@ -327,7 +327,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Inputs...</description>
       </action>
     </actions>
@@ -382,7 +382,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Outputs...</description>
       </action>
     </actions>
@@ -437,7 +437,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Time Stamps...</description>
       </action>
     </actions>
@@ -604,7 +604,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Distributed Bus...</description>
       </action>
     </actions>
@@ -659,7 +659,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Events...</description>
       </action>
     </actions>
@@ -1111,7 +1111,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Prescalers...</description>
       </action>
     </actions>
@@ -1632,7 +1632,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Interrupts...</description>
       </action>
     </actions>
@@ -1687,7 +1687,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>SFP Module...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/Main_VME-EVR-230RF.opi
+++ b/opi/boy/EVR/Main_VME-EVR-230RF.opi
@@ -10,7 +10,7 @@
   <background_color>
     <color red="240" green="240" blue="240" />
   </background_color>
-  <boy_version>5.1.0.202009030828</boy_version>
+  <boy_version>5.1.0.202204071456</boy_version>
   <foreground_color>
     <color red="192" green="192" blue="192" />
   </foreground_color>
@@ -41,7 +41,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>General Settings...</description>
       </action>
     </actions>
@@ -58,7 +58,7 @@
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -102,7 +102,7 @@ $(pv_value)</tooltip>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <foreground_color>
       <color red="0" green="0" blue="0" />
@@ -142,7 +142,7 @@ $(pv_value)</tooltip>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <foreground_color>
       <color red="0" green="0" blue="0" />
@@ -183,7 +183,7 @@ EVG or EVR</text>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="19" style="1" pixels="false">Header 1</opifont.name>
+      <opifont.name fontName="Tahoma" height="17" style="1" pixels="false">Header 1</opifont.name>
     </font>
     <foreground_color>
       <color red="0" green="0" blue="0" />
@@ -217,7 +217,7 @@ EVG or EVR</text>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Event Clock...</description>
       </action>
     </actions>
@@ -234,7 +234,7 @@ EVG or EVR</text>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -272,7 +272,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Pulse Generators...</description>
       </action>
     </actions>
@@ -289,7 +289,7 @@ $(pv_value)</tooltip>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -327,7 +327,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Inputs...</description>
       </action>
     </actions>
@@ -344,7 +344,7 @@ $(pv_value)</tooltip>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -382,7 +382,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Outputs...</description>
       </action>
     </actions>
@@ -399,7 +399,7 @@ $(pv_value)</tooltip>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -437,7 +437,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Time Stamps...</description>
       </action>
     </actions>
@@ -454,7 +454,7 @@ $(pv_value)</tooltip>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -506,7 +506,7 @@ $(pv_value)</tooltip>
     <fill_arrow>true</fill_arrow>
     <fill_level>0.0</fill_level>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -562,7 +562,7 @@ $(pv_value)</tooltip>
     <fill_arrow>true</fill_arrow>
     <fill_level>0.0</fill_level>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -604,7 +604,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Distributed Bus...</description>
       </action>
     </actions>
@@ -621,7 +621,7 @@ $(pv_value)</tooltip>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -659,7 +659,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Events...</description>
       </action>
     </actions>
@@ -676,7 +676,7 @@ $(pv_value)</tooltip>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -728,7 +728,7 @@ $(pv_value)</tooltip>
     <fill_arrow>true</fill_arrow>
     <fill_level>0.0</fill_level>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -784,7 +784,7 @@ $(pv_value)</tooltip>
     <fill_arrow>true</fill_arrow>
     <fill_level>0.0</fill_level>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -841,7 +841,7 @@ $(pv_value)</tooltip>
     <fill_arrow>true</fill_arrow>
     <fill_level>0.0</fill_level>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -898,7 +898,7 @@ $(pv_value)</tooltip>
     <fill_arrow>true</fill_arrow>
     <fill_level>0.0</fill_level>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -955,7 +955,7 @@ $(pv_value)</tooltip>
     <fill_arrow>true</fill_arrow>
     <fill_level>0.0</fill_level>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -1012,7 +1012,7 @@ $(pv_value)</tooltip>
     <fill_arrow>true</fill_arrow>
     <fill_level>0.0</fill_level>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -1069,7 +1069,7 @@ $(pv_value)</tooltip>
     <fill_arrow>true</fill_arrow>
     <fill_level>0.0</fill_level>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -1111,7 +1111,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Prescalers...</description>
       </action>
     </actions>
@@ -1128,7 +1128,7 @@ $(pv_value)</tooltip>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -1180,7 +1180,7 @@ $(pv_value)</tooltip>
     <fill_arrow>true</fill_arrow>
     <fill_level>0.0</fill_level>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -1238,7 +1238,7 @@ $(pv_value)</tooltip>
     <fill_arrow>true</fill_arrow>
     <fill_level>0.0</fill_level>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -1296,7 +1296,7 @@ $(pv_value)</tooltip>
     <fill_arrow>true</fill_arrow>
     <fill_level>0.0</fill_level>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -1353,7 +1353,7 @@ $(pv_value)</tooltip>
     <fill_arrow>true</fill_arrow>
     <fill_level>0.0</fill_level>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -1412,7 +1412,7 @@ $(pv_value)</tooltip>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -1466,7 +1466,7 @@ $(pv_value)</tooltip>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -1517,7 +1517,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Interrupts...</description>
       </action>
     </actions>
@@ -1534,7 +1534,7 @@ $(pv_value)</tooltip>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
@@ -1572,7 +1572,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>SFP Module...</description>
       </action>
     </actions>
@@ -1589,7 +1589,7 @@ $(pv_value)</tooltip>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Ubuntu" height="9" style="0" pixels="false">Default</opifont.name>
+      <opifont.name fontName="Tahoma" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>

--- a/opi/boy/EVR/Outputs_MTCA-EVR-300.opi
+++ b/opi/boy/EVR/Outputs_MTCA-EVR-300.opi
@@ -79,7 +79,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/Outputs_VME-EVR-230RF.opi
+++ b/opi/boy/EVR/Outputs_VME-EVR-230RF.opi
@@ -79,7 +79,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/Prescalers_MTCA-EVR-300.opi
+++ b/opi/boy/EVR/Prescalers_MTCA-EVR-300.opi
@@ -119,7 +119,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/Prescalers_VME-EVR-230RF.opi
+++ b/opi/boy/EVR/Prescalers_VME-EVR-230RF.opi
@@ -79,7 +79,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/PulseGenerators_MTCA-EVR-300.opi
+++ b/opi/boy/EVR/PulseGenerators_MTCA-EVR-300.opi
@@ -119,7 +119,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/PulseGenerators_VME-EVR-230RF.opi
+++ b/opi/boy/EVR/PulseGenerators_VME-EVR-230RF.opi
@@ -119,7 +119,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/SFPModule.opi
+++ b/opi/boy/EVR/SFPModule.opi
@@ -79,7 +79,7 @@
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <mode>1</mode>
+        <mode>0</mode>
         <description>Overview...</description>
       </action>
     </actions>

--- a/opi/boy/EVR/TimeStamps.opi
+++ b/opi/boy/EVR/TimeStamps.opi
@@ -119,7 +119,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <replace>0</replace>
+        <replace>1</replace>
         <description>Overview...</description>
       </action>
     </actions>


### PR DESCRIPTION
As internally discussed it provides a better behavior if the sub panels you open always replace the current tab instead of opening a new tab.

Side note: Although all panels seem to use the same widget, the setting is called `<mode></mode>` whereas on some other panels it is called `<replace></replace>`