### PR TITLE
Add IOC shell functions for reading / writing registers

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -725,3 +725,67 @@ When opening this panel, a couple of macros have to be set:
 <td>PV prefix used for the Autosave PVs. This is the prefix that is specified with the <code>CONFIG_PV_PREFIX</code> macro when loading the <code>mrf-autosave-menu.db</code> file in the IOC startup file.</td>
 </tr>
 </table>
+
+
+Auxilliary IOC shell functions
+------------------------------
+
+There are a couple of IOC shell functions that are not needed during regular
+operation but can be useful for development work or when debugging.
+
+### `mrfDumpCache`
+
+The `mrfDumpCache` function can be used to dump the contents of the memory
+cache for a device. The memory cache is only filled during initialization, so
+this function is mainly useful to developers who want to see which memory
+sections are read as part of the initialization routine.
+
+Example:
+
+```
+mrfDumpCache("EVR01")
+```
+
+### `mrfReadUInt16`
+
+The `mrfReadUInt16` function can be used to directly read the value of a 16-bit
+unsigned integer register in a device.
+
+Example:
+
+```
+mrfReadUInt16("EVR01", 0x400)
+```
+
+### `mrfReadUInt32`
+
+The `mrfReadUInt32` function can be used to directly read the value of a 32-bit
+unsigned integer register in a device.
+
+Example:
+
+```
+mrfReadUInt32("EVR01", 0x100)
+```
+
+### `mrfWriteUInt16`
+
+The `mrfWriteUInt16` function can be used to directly set the value of a 16-bit
+unsigned integer register in a device.
+
+Example:
+
+```
+mrfWriteUInt16("EVR01", 0x400, 62)
+```
+
+### `mrfWriteUInt32`
+
+The `mrfWriteUInt32` function can be used to directly set the value of a 32-bit
+unsigned integer register in a device.
+
+Example:
+
+```
+mrfWriteUInt32("EVR01", 0x100, 500)
+```

--- a/mrfApp/mrfEpicsSrc/Makefile
+++ b/mrfApp/mrfEpicsSrc/Makefile
@@ -37,6 +37,10 @@ mrfEpics_SRCS += MrfWaveformInRecord.cpp
 mrfEpics_SRCS += MrfWaveformOutRecord.cpp
 mrfEpics_SRCS += mrfArrayASubRoutines.c
 mrfEpics_SRCS += mrfEpicsError.cpp
+mrfEpics_SRCS += mrfIocshReadUInt16.cpp
+mrfEpics_SRCS += mrfIocshReadUInt32.cpp
+mrfEpics_SRCS += mrfIocshWriteUInt16.cpp
+mrfEpics_SRCS += mrfIocshWriteUInt32.cpp
 mrfEpics_SRCS += mrfRecordDefinitions.cpp
 mrfEpics_SRCS += mrfRegistrarCommon.cpp
 

--- a/mrfApp/mrfEpicsSrc/mrfIocshReadUInt16.cpp
+++ b/mrfApp/mrfEpicsSrc/mrfIocshReadUInt16.cpp
@@ -1,0 +1,89 @@
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+
+#include <epicsVersion.h>
+#include <iocsh.h>
+
+#include <MrfMemoryAccess.h>
+
+#include "MrfDeviceRegistry.h"
+#include "mrfEpicsError.h"
+
+#include "mrfIocshReadUInt16.h"
+
+using namespace anka::mrf;
+using namespace anka::mrf::epics;
+
+extern "C" {
+
+static int mrfIocshFuncInternal(const iocshArgBuf *args) noexcept {
+  char *deviceId = args[0].sval;
+  std::uint32_t address = static_cast<std::uint32_t>(args[1].ival);
+  // Verify and convert the parameters.
+  if (!deviceId) {
+    errorPrintf(
+        "Device ID must be specified.");
+    return 1;
+  }
+  if (!std::strlen(deviceId)) {
+    errorPrintf(
+        "Device ID must not be empty.");
+    return 1;
+  }
+  try {
+    auto device = MrfDeviceRegistry::getInstance().getDevice(deviceId);
+    if (!device) {
+      errorPrintf("Could not find device with ID \"%s\".", deviceId);
+      return 1;
+    }
+    std::uint16_t value = device->readUInt16(address);
+    std::printf(
+      "0x%08" PRIx32 ": 0x%04" PRIx16 " (decimal value: %" PRIu16 ")\n",
+      address, value, value);
+  } catch (std::exception &e) {
+    errorPrintf("Error while reading register: %s", e.what());
+    return 1;
+  } catch (...) {
+    errorPrintf("Error while reading register: Unknown error.");
+    return 1;
+  }
+  return 0;
+}
+
+static void mrfIocshFunc(const iocshArgBuf *args) noexcept {
+
+#if EPICS_VERSION_INT >= VERSION_INT(7,0,3,1)
+  iocshSetError(mrfIocshFuncInternal(args));
+#else // EPICS_VERSION_INT >= VERSION_INT(7,0,3,1)
+  mrfIocshFuncInternal(args);
+#endif // EPICS_VERSION_INT >= VERSION_INT(7,0,3,1)
+}
+
+// Data structures needed for the iocsh mrfReadUInt32 function.
+static const iocshArg mrfIocshArg0 = { "device ID", iocshArgString };
+static const iocshArg mrfIocshArg1 = { "memory address", iocshArgInt };
+static const iocshArg * const mrfIocshArgs[] = {
+  &mrfIocshArg0, &mrfIocshArg1 };
+static const iocshFuncDef mrfIocshFuncDef = {
+  "mrfReadUInt16",
+  2,
+  mrfIocshArgs,
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+  "Read from a uint16 register in the MRF device memory.\n",
+#endif // IOCSHFUNCDEF_HAS_USAGE
+};
+
+} // extern "C"
+
+namespace anka {
+namespace mrf {
+namespace epics {
+
+void registerIocshMrfReadUInt16() {
+  ::iocshRegister(&mrfIocshFuncDef, mrfIocshFunc);
+}
+
+} // namespace epics
+} // namespace mrf
+} // namespace anka

--- a/mrfApp/mrfEpicsSrc/mrfIocshReadUInt16.h
+++ b/mrfApp/mrfEpicsSrc/mrfIocshReadUInt16.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 aquenos GmbH.
+ * Copyright 2025 Karlsruhe Institute of Technology.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * This software has been developed by aquenos GmbH on behalf of the
+ * Karlsruhe Institute of Technology's Institute for Beam Physics and
+ * Technology.
+ *
+ * This software contains code originally developed by aquenos GmbH for
+ * the s7nodave EPICS device support. aquenos GmbH has relicensed the
+ * affected poritions of code from the s7nodave EPICS device support
+ * (originally licensed under the terms of the GNU GPL) under the terms
+ * of the GNU LGPL version 3 or newer.
+ */
+
+#ifndef ANKA_MRF_EPICS_IOCSH_READ_UINT16_H
+#define ANKA_MRF_EPICS_IOCSH_READ_UINT16_H
+
+namespace anka {
+namespace mrf {
+namespace epics {
+
+/**
+ * Registers the mrfReadUInt16 IOC shell function.
+ */
+void registerIocshMrfReadUInt16();
+
+} // namespace epics
+} // namespace mrf
+} // namespace anka
+
+#endif // ANKA_MRF_EPICS_IOCSH_READ_UINT16_H

--- a/mrfApp/mrfEpicsSrc/mrfIocshReadUInt32.cpp
+++ b/mrfApp/mrfEpicsSrc/mrfIocshReadUInt32.cpp
@@ -1,0 +1,89 @@
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+
+#include <epicsVersion.h>
+#include <iocsh.h>
+
+#include <MrfMemoryAccess.h>
+
+#include "MrfDeviceRegistry.h"
+#include "mrfEpicsError.h"
+
+#include "mrfIocshReadUInt32.h"
+
+using namespace anka::mrf;
+using namespace anka::mrf::epics;
+
+extern "C" {
+
+static int mrfIocshFuncInternal(const iocshArgBuf *args) noexcept {
+  char *deviceId = args[0].sval;
+  std::uint32_t address = static_cast<std::uint32_t>(args[1].ival);
+  // Verify and convert the parameters.
+  if (!deviceId) {
+    errorPrintf(
+        "Device ID must be specified.");
+    return 1;
+  }
+  if (!std::strlen(deviceId)) {
+    errorPrintf(
+        "Device ID must not be empty.");
+    return 1;
+  }
+  try {
+    auto device = MrfDeviceRegistry::getInstance().getDevice(deviceId);
+    if (!device) {
+      errorPrintf("Could not find device with ID \"%s\".", deviceId);
+      return 1;
+    }
+    std::uint32_t value = device->readUInt32(address);
+    std::printf(
+      "0x%08" PRIx32 ": 0x%08" PRIx32 " (decimal value: %" PRIu32 ")\n",
+      address, value, value);
+  } catch (std::exception &e) {
+    errorPrintf("Error while reading register: %s", e.what());
+    return 1;
+  } catch (...) {
+    errorPrintf("Error while reading register: Unknown error.");
+    return 1;
+  }
+  return 0;
+}
+
+static void mrfIocshFunc(const iocshArgBuf *args) noexcept {
+
+#if EPICS_VERSION_INT >= VERSION_INT(7,0,3,1)
+  iocshSetError(mrfIocshFuncInternal(args));
+#else // EPICS_VERSION_INT >= VERSION_INT(7,0,3,1)
+  mrfIocshFuncInternal(args);
+#endif // EPICS_VERSION_INT >= VERSION_INT(7,0,3,1)
+}
+
+// Data structures needed for the iocsh mrfReadUInt32 function.
+static const iocshArg mrfIocshArg0 = { "device ID", iocshArgString };
+static const iocshArg mrfIocshArg1 = { "memory address", iocshArgInt };
+static const iocshArg * const mrfIocshArgs[] = {
+  &mrfIocshArg0, &mrfIocshArg1 };
+static const iocshFuncDef mrfIocshFuncDef = {
+  "mrfReadUInt32",
+  2,
+  mrfIocshArgs,
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+  "Read from a uint32 register in the MRF device memory.\n",
+#endif // IOCSHFUNCDEF_HAS_USAGE
+};
+
+} // extern "C"
+
+namespace anka {
+namespace mrf {
+namespace epics {
+
+void registerIocshMrfReadUInt32() {
+  ::iocshRegister(&mrfIocshFuncDef, mrfIocshFunc);
+}
+
+} // namespace epics
+} // namespace mrf
+} // namespace anka

--- a/mrfApp/mrfEpicsSrc/mrfIocshReadUInt32.h
+++ b/mrfApp/mrfEpicsSrc/mrfIocshReadUInt32.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 aquenos GmbH.
+ * Copyright 2025 Karlsruhe Institute of Technology.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * This software has been developed by aquenos GmbH on behalf of the
+ * Karlsruhe Institute of Technology's Institute for Beam Physics and
+ * Technology.
+ *
+ * This software contains code originally developed by aquenos GmbH for
+ * the s7nodave EPICS device support. aquenos GmbH has relicensed the
+ * affected poritions of code from the s7nodave EPICS device support
+ * (originally licensed under the terms of the GNU GPL) under the terms
+ * of the GNU LGPL version 3 or newer.
+ */
+
+#ifndef ANKA_MRF_EPICS_IOCSH_READ_UINT32_H
+#define ANKA_MRF_EPICS_IOCSH_READ_UINT32_H
+
+namespace anka {
+namespace mrf {
+namespace epics {
+
+/**
+ * Registers the mrfReadUInt32 IOC shell function.
+ */
+void registerIocshMrfReadUInt32();
+
+} // namespace epics
+} // namespace mrf
+} // namespace anka
+
+#endif // ANKA_MRF_EPICS_IOCSH_READ_UINT32_H

--- a/mrfApp/mrfEpicsSrc/mrfIocshWriteUInt16.cpp
+++ b/mrfApp/mrfEpicsSrc/mrfIocshWriteUInt16.cpp
@@ -1,0 +1,91 @@
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+
+#include <epicsVersion.h>
+#include <iocsh.h>
+
+#include <MrfMemoryAccess.h>
+
+#include "MrfDeviceRegistry.h"
+#include "mrfEpicsError.h"
+
+#include "mrfIocshWriteUInt16.h"
+
+using namespace anka::mrf;
+using namespace anka::mrf::epics;
+
+extern "C" {
+
+static int mrfIocshFuncInternal(const iocshArgBuf *args) noexcept {
+  char *deviceId = args[0].sval;
+  std::uint32_t address = static_cast<std::uint32_t>(args[1].ival);
+  std::uint16_t value = static_cast<std::uint16_t>(args[2].ival);
+  // Verify and convert the parameters.
+  if (!deviceId) {
+    errorPrintf(
+        "Device ID must be specified.");
+    return 1;
+  }
+  if (!std::strlen(deviceId)) {
+    errorPrintf(
+        "Device ID must not be empty.");
+    return 1;
+  }
+  try {
+    auto device = MrfDeviceRegistry::getInstance().getDevice(deviceId);
+    if (!device) {
+      errorPrintf("Could not find device with ID \"%s\".", deviceId);
+      return 1;
+    }
+    value = device->writeUInt16(address, value);
+    std::printf(
+      "0x%08" PRIx32 ": 0x%04" PRIx16 " (decimal value: %" PRIu16 ")\n",
+      address, value, value);
+  } catch (std::exception &e) {
+    errorPrintf("Error while writing register: %s", e.what());
+    return 1;
+  } catch (...) {
+    errorPrintf("Error while writing register: Unknown error.");
+    return 1;
+  }
+  return 0;
+}
+
+static void mrfIocshFunc(const iocshArgBuf *args) noexcept {
+
+#if EPICS_VERSION_INT >= VERSION_INT(7,0,3,1)
+  iocshSetError(mrfIocshFuncInternal(args));
+#else // EPICS_VERSION_INT >= VERSION_INT(7,0,3,1)
+  mrfIocshFuncInternal(args);
+#endif // EPICS_VERSION_INT >= VERSION_INT(7,0,3,1)
+}
+
+// Data structures needed for the iocsh mrfReadUInt32 function.
+static const iocshArg mrfIocshArg0 = { "device ID", iocshArgString };
+static const iocshArg mrfIocshArg1 = { "memory address", iocshArgInt };
+static const iocshArg mrfIocshArg2 = { "value", iocshArgInt };
+static const iocshArg * const mrfIocshArgs[] = {
+  &mrfIocshArg0, &mrfIocshArg1, &mrfIocshArg2 };
+static const iocshFuncDef mrfIocshFuncDef = {
+  "mrfWriteUInt16",
+  3,
+  mrfIocshArgs,
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+  "Write to a uint16 register in the MRF device memory.\n",
+#endif // IOCSHFUNCDEF_HAS_USAGE
+};
+
+} // extern "C"
+
+namespace anka {
+namespace mrf {
+namespace epics {
+
+void registerIocshMrfWriteUInt16() {
+  ::iocshRegister(&mrfIocshFuncDef, mrfIocshFunc);
+}
+
+} // namespace epics
+} // namespace mrf
+} // namespace anka

--- a/mrfApp/mrfEpicsSrc/mrfIocshWriteUInt16.h
+++ b/mrfApp/mrfEpicsSrc/mrfIocshWriteUInt16.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 aquenos GmbH.
+ * Copyright 2025 Karlsruhe Institute of Technology.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * This software has been developed by aquenos GmbH on behalf of the
+ * Karlsruhe Institute of Technology's Institute for Beam Physics and
+ * Technology.
+ *
+ * This software contains code originally developed by aquenos GmbH for
+ * the s7nodave EPICS device support. aquenos GmbH has relicensed the
+ * affected poritions of code from the s7nodave EPICS device support
+ * (originally licensed under the terms of the GNU GPL) under the terms
+ * of the GNU LGPL version 3 or newer.
+ */
+
+#ifndef ANKA_MRF_EPICS_IOCSH_WRITE_UINT16_H
+#define ANKA_MRF_EPICS_IOCSH_WRITE_UINT16_H
+
+namespace anka {
+namespace mrf {
+namespace epics {
+
+/**
+ * Registers the mrfWriteUInt16 IOC shell function.
+ */
+void registerIocshMrfWriteUInt16();
+
+} // namespace epics
+} // namespace mrf
+} // namespace anka
+
+#endif // ANKA_MRF_EPICS_IOCSH_WRITE_UINT16_H

--- a/mrfApp/mrfEpicsSrc/mrfIocshWriteUInt32.cpp
+++ b/mrfApp/mrfEpicsSrc/mrfIocshWriteUInt32.cpp
@@ -1,0 +1,91 @@
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+
+#include <epicsVersion.h>
+#include <iocsh.h>
+
+#include <MrfMemoryAccess.h>
+
+#include "MrfDeviceRegistry.h"
+#include "mrfEpicsError.h"
+
+#include "mrfIocshWriteUInt32.h"
+
+using namespace anka::mrf;
+using namespace anka::mrf::epics;
+
+extern "C" {
+
+static int mrfIocshFuncInternal(const iocshArgBuf *args) noexcept {
+  char *deviceId = args[0].sval;
+  std::uint32_t address = static_cast<std::uint32_t>(args[1].ival);
+  std::uint32_t value = static_cast<std::uint32_t>(args[2].ival);
+  // Verify and convert the parameters.
+  if (!deviceId) {
+    errorPrintf(
+        "Device ID must be specified.");
+    return 1;
+  }
+  if (!std::strlen(deviceId)) {
+    errorPrintf(
+        "Device ID must not be empty.");
+    return 1;
+  }
+  try {
+    auto device = MrfDeviceRegistry::getInstance().getDevice(deviceId);
+    if (!device) {
+      errorPrintf("Could not find device with ID \"%s\".", deviceId);
+      return 1;
+    }
+    value = device->writeUInt32(address, value);
+    std::printf(
+      "0x%08" PRIx32 ": 0x%08" PRIx32 " (decimal value: %" PRIu32 ")\n",
+      address, value, value);
+  } catch (std::exception &e) {
+    errorPrintf("Error while writing register: %s", e.what());
+    return 1;
+  } catch (...) {
+    errorPrintf("Error while writing register: Unknown error.");
+    return 1;
+  }
+  return 0;
+}
+
+static void mrfIocshFunc(const iocshArgBuf *args) noexcept {
+
+#if EPICS_VERSION_INT >= VERSION_INT(7,0,3,1)
+  iocshSetError(mrfIocshFuncInternal(args));
+#else // EPICS_VERSION_INT >= VERSION_INT(7,0,3,1)
+  mrfIocshFuncInternal(args);
+#endif // EPICS_VERSION_INT >= VERSION_INT(7,0,3,1)
+}
+
+// Data structures needed for the iocsh mrfReadUInt32 function.
+static const iocshArg mrfIocshArg0 = { "device ID", iocshArgString };
+static const iocshArg mrfIocshArg1 = { "memory address", iocshArgInt };
+static const iocshArg mrfIocshArg2 = { "value", iocshArgInt };
+static const iocshArg * const mrfIocshArgs[] = {
+  &mrfIocshArg0, &mrfIocshArg1, &mrfIocshArg2 };
+static const iocshFuncDef mrfIocshFuncDef = {
+  "mrfWriteUInt32",
+  3,
+  mrfIocshArgs,
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+  "Write to a uint32 register in the MRF device memory.\n",
+#endif // IOCSHFUNCDEF_HAS_USAGE
+};
+
+} // extern "C"
+
+namespace anka {
+namespace mrf {
+namespace epics {
+
+void registerIocshMrfWriteUInt32() {
+  ::iocshRegister(&mrfIocshFuncDef, mrfIocshFunc);
+}
+
+} // namespace epics
+} // namespace mrf
+} // namespace anka

--- a/mrfApp/mrfEpicsSrc/mrfIocshWriteUInt32.h
+++ b/mrfApp/mrfEpicsSrc/mrfIocshWriteUInt32.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 aquenos GmbH.
+ * Copyright 2025 Karlsruhe Institute of Technology.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * This software has been developed by aquenos GmbH on behalf of the
+ * Karlsruhe Institute of Technology's Institute for Beam Physics and
+ * Technology.
+ *
+ * This software contains code originally developed by aquenos GmbH for
+ * the s7nodave EPICS device support. aquenos GmbH has relicensed the
+ * affected poritions of code from the s7nodave EPICS device support
+ * (originally licensed under the terms of the GNU GPL) under the terms
+ * of the GNU LGPL version 3 or newer.
+ */
+
+#ifndef ANKA_MRF_EPICS_IOCSH_WRITE_UINT32_H
+#define ANKA_MRF_EPICS_IOCSH_WRITE_UINT32_H
+
+namespace anka {
+namespace mrf {
+namespace epics {
+
+/**
+ * Registers the mrfWriteUInt32 IOC shell function.
+ */
+void registerIocshMrfWriteUInt32();
+
+} // namespace epics
+} // namespace mrf
+} // namespace anka
+
+#endif // ANKA_MRF_EPICS_IOCSH_WRITE_UINT32_H

--- a/mrfApp/mrfEpicsSrc/mrfRegistrarCommon.cpp
+++ b/mrfApp/mrfEpicsSrc/mrfRegistrarCommon.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright 2016-2021 aquenos GmbH.
- * Copyright 2016-2021 Karlsruhe Institute of Technology.
+ * Copyright 2016-2025 aquenos GmbH.
+ * Copyright 2016-2025 Karlsruhe Institute of Technology.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -46,6 +46,10 @@
 
 #include "MrfDeviceRegistry.h"
 #include "mrfEpicsError.h"
+#include "mrfIocshReadUInt16.h"
+#include "mrfIocshReadUInt32.h"
+#include "mrfIocshWriteUInt16.h"
+#include "mrfIocshWriteUInt32.h"
 
 using namespace anka::mrf;
 using namespace anka::mrf::epics;
@@ -304,6 +308,10 @@ static void mrfRegistrarCommon() {
   ::iocshRegister(&iocshMrfDumpCacheFuncDef, iocshMrfDumpCacheFunc);
   ::iocshRegister(&iocshMrfMapInterruptToEventFuncDef,
       iocshMrfMapInterruptToEventFunc);
+  registerIocshMrfReadUInt16();
+  registerIocshMrfReadUInt32();
+  registerIocshMrfWriteUInt16();
+  registerIocshMrfWriteUInt32();
 }
 
 epicsExportRegistrar(mrfRegistrarCommon);


### PR DESCRIPTION
This PR adds four new IOC shell functions (`mrfReadUInt16`, `mrfReadUInt32`, `mrfWriteUInt16`, and `mrfWriteUInt32`) that can be used to directly read from or write to registers inside the memory of an MRF devices.

Closes #8.
