### PR TITLE
Allow output redirection and improve error logging

### DIFF
--- a/mrfApp/mrfEpicsSrc/mrfIocshDumpCache.cpp
+++ b/mrfApp/mrfEpicsSrc/mrfIocshDumpCache.cpp
@@ -28,9 +28,9 @@
  */
 
 #include <cinttypes>
-#include <cstdio>
 #include <cstring>
 
+#include <epicsStdio.h>
 #include <epicsVersion.h>
 #include <iocsh.h>
 
@@ -81,16 +81,16 @@ static int iocshMrfDumpCacheFuncInternal(const iocshArgBuf *args) noexcept {
       errorPrintf("Could not find cache for device with ID \"%s\".", deviceId);
       return 1;
     }
-    std::printf("uint16 registers:\n\n");
+    ::epicsStdoutPrintf("uint16 registers:\n\n");
     for (auto &addressAndValue : cache->getCacheUInt16()) {
-      std::printf(
+      ::epicsStdoutPrintf(
         "0x%08" PRIx32 ": 0x%04" PRIx16 "\n",
         addressAndValue.first,
         addressAndValue.second);
     }
-    std::printf("\n\nuint32 registers:\n\n");
+    ::epicsStdoutPrintf("\n\nuint32 registers:\n\n");
     for (auto &addressAndValue : cache->getCacheUInt32()) {
-      std::printf(
+      ::epicsStdoutPrintf(
         "0x%08" PRIx32 ": 0x%08" PRIx32 "\n",
         addressAndValue.first,
         addressAndValue.second);

--- a/mrfApp/mrfEpicsSrc/mrfIocshReadUInt16.cpp
+++ b/mrfApp/mrfEpicsSrc/mrfIocshReadUInt16.cpp
@@ -28,10 +28,10 @@
  */
 
 #include <cinttypes>
-#include <stdexcept>
-#include <cstdio>
 #include <cstring>
+#include <stdexcept>
 
+#include <epicsStdio.h>
 #include <epicsVersion.h>
 #include <iocsh.h>
 
@@ -68,7 +68,7 @@ static int mrfIocshFuncInternal(const iocshArgBuf *args) noexcept {
       return 1;
     }
     std::uint16_t value = device->readUInt16(address);
-    std::printf(
+    ::epicsStdoutPrintf(
       "0x%08" PRIx32 ": 0x%04" PRIx16 " (decimal value: %" PRIu16 ")\n",
       address, value, value);
   } catch (std::exception &e) {

--- a/mrfApp/mrfEpicsSrc/mrfIocshReadUInt32.cpp
+++ b/mrfApp/mrfEpicsSrc/mrfIocshReadUInt32.cpp
@@ -28,10 +28,10 @@
  */
 
 #include <cinttypes>
-#include <stdexcept>
-#include <cstdio>
 #include <cstring>
+#include <stdexcept>
 
+#include <epicsStdio.h>
 #include <epicsVersion.h>
 #include <iocsh.h>
 
@@ -68,7 +68,7 @@ static int mrfIocshFuncInternal(const iocshArgBuf *args) noexcept {
       return 1;
     }
     std::uint32_t value = device->readUInt32(address);
-    std::printf(
+    ::epicsStdoutPrintf(
       "0x%08" PRIx32 ": 0x%08" PRIx32 " (decimal value: %" PRIu32 ")\n",
       address, value, value);
   } catch (std::exception &e) {

--- a/mrfApp/mrfEpicsSrc/mrfIocshWriteUInt16.cpp
+++ b/mrfApp/mrfEpicsSrc/mrfIocshWriteUInt16.cpp
@@ -28,10 +28,10 @@
  */
 
 #include <cinttypes>
-#include <stdexcept>
-#include <cstdio>
 #include <cstring>
+#include <stdexcept>
 
+#include <epicsStdio.h>
 #include <epicsVersion.h>
 #include <iocsh.h>
 
@@ -69,7 +69,7 @@ static int mrfIocshFuncInternal(const iocshArgBuf *args) noexcept {
       return 1;
     }
     value = device->writeUInt16(address, value);
-    std::printf(
+    ::epicsStdoutPrintf(
       "0x%08" PRIx32 ": 0x%04" PRIx16 " (decimal value: %" PRIu16 ")\n",
       address, value, value);
   } catch (std::exception &e) {

--- a/mrfApp/mrfEpicsSrc/mrfIocshWriteUInt32.cpp
+++ b/mrfApp/mrfEpicsSrc/mrfIocshWriteUInt32.cpp
@@ -28,10 +28,10 @@
  */
 
 #include <cinttypes>
-#include <stdexcept>
-#include <cstdio>
 #include <cstring>
+#include <stdexcept>
 
+#include <epicsStdio.h>
 #include <epicsVersion.h>
 #include <iocsh.h>
 
@@ -69,7 +69,7 @@ static int mrfIocshFuncInternal(const iocshArgBuf *args) noexcept {
       return 1;
     }
     value = device->writeUInt32(address, value);
-    std::printf(
+    ::epicsStdoutPrintf(
       "0x%08" PRIx32 ": 0x%08" PRIx32 " (decimal value: %" PRIu32 ")\n",
       address, value, value);
   } catch (std::exception &e) {


### PR DESCRIPTION
This PR enables output redirection in the IOC shell for all the IOC shell functions that are provided by this device support.

It also improves the error logging function to use the errlog facility provided by EPICS Base whenever possible. And to also respect output redirections which are in force for the current thread.

Closes #12.